### PR TITLE
Fix gRPC server start

### DIFF
--- a/service-a-grpc/src/server.ts
+++ b/service-a-grpc/src/server.ts
@@ -40,9 +40,18 @@ async function main() {
     });
 
     const PORT = '0.0.0.0:50051';
-    server.bindAsync(PORT, grpc.ServerCredentials.createInsecure(), () => {
-        console.log(`🚀 gRPC Server running at ${PORT}`);
-    });
+    server.bindAsync(
+        PORT,
+        grpc.ServerCredentials.createInsecure(),
+        (err) => {
+            if (err) {
+                console.error('💥 Failed to bind gRPC server:', err);
+                return;
+            }
+            server.start();
+            console.log(`🚀 gRPC Server running at ${PORT}`);
+        }
+    );
 }
 
 main();


### PR DESCRIPTION
## Summary
- bind gRPC server and start it after binding completes

## Testing
- `npm test` in `service-a-grpc`
- `npm test` in `service-b-rest`


------
https://chatgpt.com/codex/tasks/task_e_6844f038e280832fb9fbfef5cd6e9ba9